### PR TITLE
MemberService 구현 및 패키지 리팩토링

### DIFF
--- a/mbting/src/main/java/kau/coop/mbting/controller/login/SessionManager.java
+++ b/mbting/src/main/java/kau/coop/mbting/controller/login/SessionManager.java
@@ -1,0 +1,64 @@
+package kau.coop.mbting.controller.login;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class SessionManager {
+
+    private static final String SESSION_COOKIE_NAME = "sessionId";
+    private Map<String, Object> sessionStore = new ConcurrentHashMap<>();
+
+    /**
+     * 세션 생성
+     * @param value
+     * @param response
+     */
+    public void createSession(Object value, HttpServletResponse response){
+        String sessionId = UUID.randomUUID().toString();
+        sessionStore.put(sessionId, value);
+
+        Cookie mySessionCookie = new Cookie(SESSION_COOKIE_NAME, sessionId);
+        response.addCookie(mySessionCookie);
+    }
+
+    /**
+     * 세션 조회
+     * @param request
+     * @return
+     */
+    public Object getSession(HttpServletRequest request) {
+        Cookie sessionCookie = findCookie(request, SESSION_COOKIE_NAME);
+        if (sessionCookie == null) {
+            return null;
+        }
+
+        return sessionStore.get(sessionCookie.getValue());
+    }
+
+    /**
+     * 세션 만료
+     * @param request
+     */
+    public void expire(HttpServletRequest request) {
+        Cookie sessionCookie = findCookie(request, SESSION_COOKIE_NAME);
+        if(sessionCookie != null) {
+            sessionStore.remove(sessionCookie.getValue());
+        }
+    }
+
+    private Cookie findCookie(HttpServletRequest request, String cookieName) {
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> cookie.getName().equals(cookieName))
+                .findAny()
+                .orElse(null);
+    }
+
+
+}

--- a/mbting/src/main/java/kau/coop/mbting/domain/member/Gender.java
+++ b/mbting/src/main/java/kau/coop/mbting/domain/member/Gender.java
@@ -1,6 +1,0 @@
-package kau.coop.mbting.domain.member;
-
-public enum Gender {
-    MALE,
-    FEMALE,
-}

--- a/mbting/src/main/java/kau/coop/mbting/domain/member/Member.java
+++ b/mbting/src/main/java/kau/coop/mbting/domain/member/Member.java
@@ -1,36 +1,33 @@
 package kau.coop.mbting.domain.member;
 
+import kau.coop.mbting.domain.member.memberinfo.MemberInfo;
 import lombok.Getter;
 
-// 범위 지정이 가능한 mbti, gender, address 등은 최대한 enum class를 이용하였습니다.
 @Getter
 public class Member {
 
     /**
      * 고유 ID로 회원 조회할 때 사용합니다.
      */
-    private Long id;
-    private String nickname;
-    private Gender gender;
-    private Long age;
-    private Academy academy;
-    private Mbti mbti;
-    private Address address;
-    private Hobby hobby;
+    private Long identityId;
+    private String id;
+    private String passwd;
+    private MemberInfo memberInfo;
 
-
-
-    public Member(String nickname, Gender gender, Long age, Academy academy, Mbti mbti, Address address, Hobby hobby) {
-        this.nickname = nickname;
-        this.gender = gender;
-        this.age = age;
-        this.academy = academy;
-        this.mbti = mbti;
-        this.address = address;
-        this.hobby = hobby;
+    public Member(String id, String passwd) {
+        this.id = id;
+        this.passwd = passwd;
     }
 
-    public void setId(Long id) {
-        this.id = id;
+    public void setIdentityId(Long identityId) {
+        this.identityId = identityId;
+    }
+
+    public void setPasswd(String passwd) {
+        this.passwd = passwd;
+    }
+
+    public void setMemberInfo(MemberInfo memberInfo) {
+        this.memberInfo = memberInfo;
     }
 }

--- a/mbting/src/main/java/kau/coop/mbting/domain/member/memberinfo/Academy.java
+++ b/mbting/src/main/java/kau/coop/mbting/domain/member/memberinfo/Academy.java
@@ -1,4 +1,4 @@
-package kau.coop.mbting.domain.member;
+package kau.coop.mbting.domain.member.memberinfo;
 
 public enum Academy {
     한국항공대학교,

--- a/mbting/src/main/java/kau/coop/mbting/domain/member/memberinfo/Address.java
+++ b/mbting/src/main/java/kau/coop/mbting/domain/member/memberinfo/Address.java
@@ -1,4 +1,4 @@
-package kau.coop.mbting.domain.member;
+package kau.coop.mbting.domain.member.memberinfo;
 
 public enum Address {
 

--- a/mbting/src/main/java/kau/coop/mbting/domain/member/memberinfo/Gender.java
+++ b/mbting/src/main/java/kau/coop/mbting/domain/member/memberinfo/Gender.java
@@ -1,0 +1,6 @@
+package kau.coop.mbting.domain.member.memberinfo;
+
+public enum Gender {
+    MALE,
+    FEMALE,
+}

--- a/mbting/src/main/java/kau/coop/mbting/domain/member/memberinfo/Hobby.java
+++ b/mbting/src/main/java/kau/coop/mbting/domain/member/memberinfo/Hobby.java
@@ -1,4 +1,4 @@
-package kau.coop.mbting.domain.member;
+package kau.coop.mbting.domain.member.memberinfo;
 
 public enum Hobby {
     운동,

--- a/mbting/src/main/java/kau/coop/mbting/domain/member/memberinfo/Mbti.java
+++ b/mbting/src/main/java/kau/coop/mbting/domain/member/memberinfo/Mbti.java
@@ -1,4 +1,4 @@
-package kau.coop.mbting.domain.member;
+package kau.coop.mbting.domain.member.memberinfo;
 
 public enum Mbti {
     ISTJ,

--- a/mbting/src/main/java/kau/coop/mbting/domain/member/memberinfo/MemberInfo.java
+++ b/mbting/src/main/java/kau/coop/mbting/domain/member/memberinfo/MemberInfo.java
@@ -1,0 +1,16 @@
+package kau.coop.mbting.domain.member.memberinfo;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MemberInfo {
+    private String nickname;
+    private Gender gender;
+    private Long age;
+    private Academy academy;
+    private Mbti mbti;
+    private Address address;
+    private Hobby hobby;
+}

--- a/mbting/src/main/java/kau/coop/mbting/domain/member/memberinfo/MemberInfo.java
+++ b/mbting/src/main/java/kau/coop/mbting/domain/member/memberinfo/MemberInfo.java
@@ -13,4 +13,14 @@ public class MemberInfo {
     private Mbti mbti;
     private Address address;
     private Hobby hobby;
+
+    public MemberInfo(String nickname, Gender gender, Long age, Academy academy, Mbti mbti, Address address, Hobby hobby) {
+        this.nickname = nickname;
+        this.gender = gender;
+        this.age = age;
+        this.academy = academy;
+        this.mbti = mbti;
+        this.address = address;
+        this.hobby = hobby;
+    }
 }

--- a/mbting/src/main/java/kau/coop/mbting/repository/account/AccountRepository.java
+++ b/mbting/src/main/java/kau/coop/mbting/repository/account/AccountRepository.java
@@ -1,4 +1,0 @@
-package kau.coop.mbting.repository.account;
-
-public interface AccountRepository {
-}

--- a/mbting/src/main/java/kau/coop/mbting/repository/member/MemberRepository.java
+++ b/mbting/src/main/java/kau/coop/mbting/repository/member/MemberRepository.java
@@ -9,7 +9,10 @@ public interface MemberRepository {
 
     Member save(Member member);
 
-    Optional<Member> findById(Long memberId);
+    Member update(Member member);
+
+    Optional<Member> findById(Long identifyId);
+    Optional<Member> findById(String userId);
 
     Optional<Member> findByNickname(String nickname);
 

--- a/mbting/src/main/java/kau/coop/mbting/repository/member/MemoryMemberRepository.java
+++ b/mbting/src/main/java/kau/coop/mbting/repository/member/MemoryMemberRepository.java
@@ -4,18 +4,25 @@ import kau.coop.mbting.domain.member.Member;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Component
 public class MemoryMemberRepository implements MemberRepository {
 
-    private static Map<Long, Member> store = new HashMap<>();
+    private static Map<Long, Member> store = new ConcurrentHashMap<>();
 
     private static long sequence = 0L;
 
     @Override
     public Member save(Member member) {
-        member.setId(sequence++);
-        store.put(member.getId(), member);
+        member.setIdentityId(sequence++);
+        store.put(member.getIdentityId(), member);
+        return member;
+    }
+
+    @Override
+    public Member update(Member member) {
+        store.put(member.getIdentityId(), member);
         return member;
     }
 
@@ -26,9 +33,16 @@ public class MemoryMemberRepository implements MemberRepository {
     }
 
     @Override
+    public Optional<Member> findById(String userId) {
+        return store.values().stream()
+                .filter( member -> member.getId().equals(userId))
+                .findAny();
+    }
+
+    @Override
     public Optional<Member> findByNickname(String nickname) {
          return store.values().stream()
-                .filter( member -> member.getNickname().equals(nickname))
+                .filter( member -> member.getMemberInfo().getNickname().equals(nickname))
                 .findAny();
     }
 

--- a/mbting/src/main/java/kau/coop/mbting/service/member/MemberService.java
+++ b/mbting/src/main/java/kau/coop/mbting/service/member/MemberService.java
@@ -1,7 +1,7 @@
 package kau.coop.mbting.service.member;
 
 import kau.coop.mbting.domain.member.Member;
-import kau.coop.mbting.repository.member.MemberRepository;
+import kau.coop.mbting.domain.member.memberinfo.MemberInfo;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,9 +10,22 @@ public interface MemberService {
 
     /**
      * 회원가입
-     * @param member
+     * @param passwd 비밀번호
+     * @param passwdVerify 비밀번호 확인
      */
-    void join(Member member);
+     Member register(String id, String passwd, String passwdVerify) throws Exception;
+
+
+    /**
+     * 비밀번호 변경
+     * @throws Exception
+     */
+    void changePasswd(String id, String passwd, String newPasswd) throws Exception;
+
+    /**
+     * 회원 정보 저장 & 업데이트
+     */
+    void updateMemberInfo(Long identifyId, MemberInfo memberInfo);
 
     /**
      * 회원 하나 조회
@@ -32,6 +45,7 @@ public interface MemberService {
      * @param memberId
      */
     void quit(Long memberId);
+
 
 
 }

--- a/mbting/src/main/java/kau/coop/mbting/service/member/MemberServiceImpl.java
+++ b/mbting/src/main/java/kau/coop/mbting/service/member/MemberServiceImpl.java
@@ -1,13 +1,15 @@
 package kau.coop.mbting.service.member;
 
 import kau.coop.mbting.domain.member.Member;
+import kau.coop.mbting.domain.member.memberinfo.MemberInfo;
 import kau.coop.mbting.repository.member.MemberRepository;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
-@Component
+@Service
 public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
@@ -17,8 +19,32 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public void join(Member member) {
+    public Member register(String id, String passwd, String passwdVerify) throws Exception {
+        if (memberRepository.findById(id).isPresent()) {
+            throw new Exception("이미 존재하는 ID 입니다.");
+        }
+        if (!passwd.equals(passwdVerify)) {
+            throw new Exception("입력한 두 비밀번호가 일치하지 않습니다");
+        }
+        Member member = new Member(id, passwd);
         memberRepository.save(member);
+        return member;
+    }
+
+    @Override
+    public void changePasswd(String id, String passwd, String newPasswd) throws Exception {
+        Member member = verifyAccount(id, passwd);
+        member.setPasswd(newPasswd);
+        memberRepository.update(member);
+    }
+
+    @Override
+    public void updateMemberInfo(Long identifyId, MemberInfo memberInfo) {
+        memberRepository.findById(identifyId)
+                .ifPresent(member -> {
+                    member.setMemberInfo(memberInfo);
+                    memberRepository.update(member);
+                });
     }
 
     @Override
@@ -34,5 +60,14 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public void quit(Long memberId) {
         memberRepository.delete(memberId);
+    }
+
+    private Member verifyAccount(String id, String passwd) throws NoSuchElementException {
+        Member member = memberRepository.findById(id).orElseThrow();
+        if (member.getPasswd().equals(passwd)) {
+            return member;
+        } else {
+            throw new NoSuchElementException("해당 계정 정보가 없습니다.");
+        }
     }
 }

--- a/mbting/src/test/java/kau/coop/mbting/member/MemberServiceTest.java
+++ b/mbting/src/test/java/kau/coop/mbting/member/MemberServiceTest.java
@@ -1,17 +1,18 @@
 package kau.coop.mbting.member;
 
 import kau.coop.mbting.domain.member.*;
+import kau.coop.mbting.domain.member.memberinfo.*;
 import kau.coop.mbting.repository.member.MemberRepository;
 import kau.coop.mbting.repository.member.MemoryMemberRepository;
 import kau.coop.mbting.service.member.MemberService;
 import kau.coop.mbting.service.member.MemberServiceImpl;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
+import java.util.ArrayList;
+import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -19,6 +20,7 @@ public class MemberServiceTest {
 
     MemberRepository memberRepository;
     MemberService memberService;
+
     @BeforeEach
     void beforeEach() {
         memberRepository = new MemoryMemberRepository();
@@ -31,29 +33,84 @@ public class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("회원가입")
-    void join() {
-        Member member = new Member("hhtboy", Gender.MALE, 24L, Academy.한국항공대학교, Mbti.INTJ, Address.강서, Hobby.게임);
+    @DisplayName("회원 가입")
+    void register() {
 
-        memberService.join(member);
+        try {
+            //given
+            Member member = memberService.register("testId", "testPasswd", "testPasswd");
 
-        Optional<Member> member2 = memberService.findOne(member.getId());
+            //when
+            Member member1 = memberService.findOne(member.getIdentityId()).get();
 
-        assertThat(member).isEqualTo(member2.get());
+            //then
+            assertThat(member1.getId()).isEqualTo("testId");
+            assertThat(member1.getPasswd()).isEqualTo("testPasswd");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    @DisplayName("중복 계정 검사")
+    void validateAccount() throws Exception {
+        //given
+        Member member1;
+        Member member2;
+        member1 = memberService.register("testId", "testPasswd123", "testPasswd123");
+
+        //when
+        try {
+            memberService.register("testId", "testPasswd", "testPasswd");
+            fail("중복 계정 검사를 실패");
+        }catch (Exception e) {
+            assertThat(e).isInstanceOf(Exception.class);
+        }
     }
 
     @Test
     @DisplayName("회원 삭제")
-    void delete() {
-        Member member = new Member("hhtboy", Gender.MALE, 24L, Academy.한국항공대학교, Mbti.INTJ, Address.강서, Hobby.게임);
+    void delete() throws Exception {
+        //given
+        Member member;
+        member = memberService.register("testId", "testPasswd", "testPasswd");
+        assertThat(member).isEqualTo(memberService.findOne(member.getIdentityId()).get());
 
-        memberService.join(member);
-        assertThat(member).isEqualTo(memberService.findOne(member.getId()).get());
+        //when
+        memberService.quit(member.getIdentityId());
 
-        memberService.quit(member.getId());
-        assertThat(memberService.findOne(member.getId())
+        //then
+        assertThat(memberService.findOne(member.getIdentityId())
                 .isEmpty())
                 .isTrue();
     }
 
+    @Test
+    @DisplayName("회원 정보 업데이트")
+    void update() throws Exception {
+        //given
+        Member member;
+        MemberInfo memberInfo = new MemberInfo("testNick", Gender.MALE, 24L, Academy.한국항공대학교, Mbti.INTJ, Address.강서, Hobby.게임);
+        member = memberService.register("testId", "testPasswd", "testPasswd");
+
+        //when
+        memberService.updateMemberInfo(member.getIdentityId(), memberInfo);
+
+        //then
+        assertThat(memberService.findOne(member.getIdentityId()).get().getMemberInfo()).isEqualTo(memberInfo);
+
+    }
+
+    @Test
+    @DisplayName("passwd 변경")
+    void changePasswd() throws Exception {
+        //given
+        Member member = memberService.register("testId", "testPasswd", "testPasswd");
+
+        //when
+        memberService.changePasswd(member.getId(), member.getPasswd(), "newPasswd");
+
+        //then
+        assertThat(member.getPasswd()).isEqualTo("newPasswd");
+    }
 }

--- a/mbting/src/test/java/kau/coop/mbting/scan/AutoAppConfigTest.java
+++ b/mbting/src/test/java/kau/coop/mbting/scan/AutoAppConfigTest.java
@@ -6,6 +6,7 @@ import kau.coop.mbting.service.member.MemberService;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.servlet.context.AnnotationConfigServletWebApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 import static org.assertj.core.api.Assertions.*;
@@ -14,7 +15,7 @@ public class AutoAppConfigTest {
 
     @Test
     void basicScan() {
-        AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(AutoAppConfig.class);
+        AnnotationConfigServletWebApplicationContext ac = new AnnotationConfigServletWebApplicationContext(AutoAppConfig.class);
 
         MemberService memberService = ac.getBean(MemberService.class);
         assertThat(memberService).isInstanceOf(MemberService.class);


### PR DESCRIPTION
기존에는 계정 정보와 멤버 정보를 분리하였는데(아이디, 비번을 다른 정보와 분리), 이 방식으로 하면 데이터 접근시 너무 복잡해서 계정 정보도 멤버 정보에 함께 저장하였습니다.
Member Service의 역할은 다음과 같습니다.
- 회원 가입(아이디, 비번)
- 회원 정보 저장&업데이트(회원가입 이후 설문을 통해 들어올 정보)
- 비밀번호 변경
- 회원조회(하나, 전부)
- 회원 탈퇴

로그인 시 필요한 세션을 관리해줄 Session Manager를 구현하였습니다.
이후 로그인 서비스에 대한 인터페이스를 짜 보겠습니다.